### PR TITLE
Add Windows build workflow

### DIFF
--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -1,0 +1,25 @@
+name: Build Windows Executable
+
+on:
+  workflow_dispatch:
+  push:
+    branches: ["main"]
+
+jobs:
+  build-win:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - name: Install dependencies
+        run: npm install
+      - name: Build executable
+        run: npm run dist
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: StreamDeckEnhanced-win32
+          path: "dist/StreamDeck Enhanced.exe"

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules/
 dist/
 *.log
+dist2/


### PR DESCRIPTION
## Summary
- add GitHub Action workflow to build a Windows executable using `npm run dist`
- ignore future build artifacts

## Testing
- `npm run dist` *(fails: wine is required)*

------
https://chatgpt.com/codex/tasks/task_e_68406d6391108331bf943f9d39615a6f